### PR TITLE
Fix plugin package name

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -1,5 +1,5 @@
 services:
-    noud.saml2:
+    auth.provider.noud.saml2:
         class: noud\saml2\auth\provider\auth_simplesaml
         arguments:
             - '@dbal.conn'


### PR DESCRIPTION
Without the "auth.provider" prefix, phpBB 3.2 fails to find the package using its name as an identifier.

I'm not sure how it ever worked before, this might be a 3.2 specific requirement :  

```php
if (array_key_exists('auth.provider.' . $method, $auth_providers))
{
	/* SUCCESS */
}
else
{
	trigger_error('NO_AUTH_PLUGIN', E_USER_ERROR);
}
```